### PR TITLE
Fixes #5 Updates the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,21 @@ run the versions of `proton-ge-custom` that `humble-lumpia` will download. Be
 sure to reference the [README](https://github.com/GloriousEggroll/proton-ge-custom/)
 in `proton-ge-custom` to determine what other dependencies your system requires.
 
-### AUR Package Installation
+### From AUR
 
 If you are running **Arch Linux**, you can also download and install the 
-package maintained by [NINNiT](https://github.com/NINNiT) from the AUR. 
+package maintained by [NINNiT](https://github.com/NINNiT) from the [AUR](https://aur.archlinux.org/packages/humble-lumpia-git/). 
+
+If you are already using `yay` as an AUR helper, then you can
+run the following command to install humble-lumpia.
+
+```shell
+yay -S humble-lumpia-git
+```
+
 If you are unfamiliar with installing packages from the AUR, you can 
 review the process [here](https://wiki.archlinux.org/title/Arch_User_Repository#Installing_and_upgrading_packages)
-in the Arch Wiki.
+in the Arch Wiki. 
 
 ### From Source
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,35 @@ A 'package manager' for Glorious Eggroll's custom proton build.
 
 ## Installation
 
+There are currently a couple of ways to install `humble-lumpia`.
+
+### AUR Package Installation
+
+If you are running **Arch Linux**, you can also download and install the 
+package maintained by [NINNiT](https://github.com/NINNiT) from the AUR. 
+If you are unfamiliar with installing packages from the AUR, you can 
+review the process [here](https://wiki.archlinux.org/title/Arch_User_Repository#Installing_and_upgrading_packages)
+in the Arch Wiki.
+
+### From Source
+
+It is also possible to easily install the utility from source. If you wish to 
+do so, please ensure that you have the appropriate dependencies to 
+[build](#build-dependencies) and [run](#runtime-dependencies) the application 
+as mentioned below.
+
 ```shell
 sudo make install
 ```
+
+#### Build Dependencies
+
+* make
+
+#### Runtime Dependencies
+
+* curl
+* jq
 
 ## Uninstallation
 

--- a/README.md
+++ b/README.md
@@ -29,14 +29,7 @@ in the Arch Wiki.
 
 ### From Source
 
-It is also possible to easily install the utility from source. If you wish to 
-do so, please ensure that you have the appropriate dependencies to 
-[build](#build-dependencies) and [run](#runtime-dependencies) the application 
-as mentioned below.
-
-```shell
-sudo make install
-```
+It is also possible to install `humble-lumpia` from source.
 
 #### Build Dependencies
 
@@ -46,6 +39,12 @@ sudo make install
 
 * curl
 * jq
+
+#### Install Command
+
+```shell
+sudo make install
+```
 
 ## Uninstallation
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ A 'package manager' for Glorious Eggroll's custom proton build.
 
 There are currently a couple of ways to install `humble-lumpia`.
 
+**NOTE:** Installing `humble-lumpia` and its dependencies is not sufficient to 
+run the versions of `proton-ge-custom` that `humble-lumpia` will download. Be 
+sure to reference the [README](https://github.com/GloriousEggroll/proton-ge-custom/)
+in `proton-ge-custom` to determine what other dependencies your system requires.
+
 ### AUR Package Installation
 
 If you are running **Arch Linux**, you can also download and install the 


### PR DESCRIPTION
Updates the README file with more detailed instructions for how
to install `humble-lumpia` from source as well as details for
how to install it from the Arch User Repository.
