### PR TITLE
Add support for versions 10-26+

### DIFF
--- a/humble-lumpia
+++ b/humble-lumpia
@@ -27,7 +27,7 @@ getAllReleasesData() {
 	test -e "$RELEASES_FILE" || updateReleaseData;
 
     if test -e "$RELEASES_FILE"; then
-		jq '[.[] | { name: .tag_name, published_at, url: .assets[] | select(.content_type == "application/gzip" or (.content_type=="binary/octet-stream") and (.name | test("\\.tar\\.gz"))) | .url }] | sort_by(.published_at)' \
+		jq '[.[] | { name: .tag_name, published_at, url: .assets[] | select(.content_type == "application/gzip" or .content_type == "application/x-gtar" or (.content_type=="binary/octet-stream") and (.name | test("\\.tar\\.gz"))) | .url }] | sort_by(.published_at)' \
 			< "$RELEASES_FILE";
     fi
 }


### PR DESCRIPTION
The content_type in the releases feed has changed from `application/gzip` to `application/x-gtar`.

This updates the jq filter to include `application/x-gtar`.